### PR TITLE
Do not use SSO to guard access to dav.php

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -58,6 +58,9 @@ ram.runtime = "50M"
     admin.url = "/admin"
     admin.allowed= "admins"
     admin.show_tile = false
+    dav.url = "/dav.php"
+    dav.allowed = "visitors"
+    dav.show_tile = false
 
     [resources.apt]
     packages = "mariadb-server, php8.0-xml, php8.0-mbstring, php8.0-mysql, php8.0-ldap"


### PR DESCRIPTION
Access to the dav.php does not need to be protected via SSO, as DAV clients will not have an active session but authenticate via LDAP instead.

## Problem

- Calendars can not be added via Thunderbird, as access to the dav.php URLs is guarded by SSO

## Solution

- Allow access to the dav.php for visitors, who then authenticate via LDAP

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
