### PR TITLE
Add explaining help text

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -41,6 +41,7 @@ ram.runtime = "50M"
     [install.init_main_permission]
     type = "group"
     default = "all_users"
+    help.en = "If you want to access Baikal with CalDAV or CardDAV clients, you need to allow access for visitors."
 
     [install.password]
     type = "password"


### PR DESCRIPTION
## Problem

- There was no hint that Baikal must be accessible anonymously to allow access with DAV clients.

## Solution

- Add a help text that is displayed during installation (only in English).

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
