### PR TITLE
Enable anonymous access by default

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -38,11 +38,6 @@ ram.runtime = "50M"
     type = "path"
     default = "/baikal"
 
-    [install.init_main_permission]
-    type = "group"
-    default = "all_users"
-    help.en = "If you want to access Baikal with CalDAV or CardDAV clients, you need to allow access for visitors."
-
     [install.password]
     type = "password"
 
@@ -58,9 +53,10 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    main.allowed = "visitors"
     main.auth_header = false
     admin.url = "/admin"
-    admin.allowed= "admins"
+    admin.allowed = "admins"
     admin.show_tile = false
 
     [resources.apt]


### PR DESCRIPTION
## Problem

- Baikal is only available to DAV clients if access for visitors is explicitly enabled

## Solution

- Make access to the DAV endpoints available for anonymous access
- See https://forum.yunohost.org/t/baikal-improvements/28015

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
